### PR TITLE
error breakdowns for YODA

### DIFF
--- a/hepdata_converter/testsuite/testdata/yoda/full.yoda
+++ b/hepdata_converter/testsuite/testdata/yoda/full.yoda
@@ -1,4 +1,6 @@
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d01-x01-y01
+ErrorBreakdown: {0: {stat: {dn: -3.0, up: 3.3}, sys: {dn: -1.2, up: 1}, 'sys,lumi': {dn: -1, up: 1}}, 1: {stat: {dn: -3.5, up: 3.8}, sys: {dn: -1.5, up: 1.7}, 'sys,lumi': {dn: -1.2, up: 1.2}}, 2: {stat: {dn: -2.9, up: 3.1}, sys: {dn: -1.7, up: 1.7}, 'sys,lumi': {dn: -0.5, up: 0.5}}}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d01-x01-y01
 Title: Table 1
@@ -10,6 +12,8 @@ Type: Scatter2D
 9.000000e+03	0.000000e+00	0.000000e+00	1.270000e+01	3.398529e+00	3.570714e+00
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER3D_V2 /REF/RIVET_ANALYSIS_NAME/d02-x01-y01
+ErrorBreakdown: {}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d02-x01-y01
 Title: Table 2
@@ -48,6 +52,8 @@ Type: Scatter3D
 7.900000e+02	0.000000e+00	0.000000e+00	8.000000e+02	0.000000e+00	0.000000e+00	2.502000e-04	0.000000e+00	0.000000e+00
 END YODA_SCATTER3D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d03-x01-y01
+ErrorBreakdown: {0: {stat: {dn: -1100, up: 1100}, 'sys,background': {dn: -15, up: 15}, 'sys,detector': {dn: -79, up: 79}}, 1: {stat: {dn: -1600, up: 1600}, 'sys,background': {dn: -15, up: 15}, 'sys,detector': {dn: -75, up: 75}}, 2: {stat: {dn: -490, up: 490}, 'sys,background': {dn: -2, up: 2}, 'sys,detector': {dn: -41, up: 41}}, 3: {stat: {dn: -60, up: 60}, 'sys,background': {dn: 0, up: 0}, 'sys,detector': {dn: -2, up: 2}}}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d03-x01-y01
 Title: Table 3
@@ -60,6 +66,8 @@ Type: Scatter2D
 4.000000e+02	2.000000e+02	2.000000e+02	8.000000e+01	6.003332e+01	6.003332e+01
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d04-x01-y01
+ErrorBreakdown: {0: {stat: {dn: -3340, up: 3340}, 'sys,background': {dn: -740, up: 740}, 'sys,detector': {dn: -80, up: 80}}, 1: {stat: {dn: -3210, up: 3210}, 'sys,background': {dn: -260, up: 260}, 'sys,detector': {dn: -200, up: 200}}, 2: {stat: {dn: -1490, up: 1490}, 'sys,background': {dn: -390, up: 390}, 'sys,detector': {dn: -120, up: 120}}}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d04-x01-y01
 Title: Table 4
@@ -71,6 +79,8 @@ Type: Scatter2D
 1.650000e+02	3.500000e+01	3.500000e+01	3.900000e+03	1.544862e+03	1.544862e+03
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d05-x01-y01
+ErrorBreakdown: {0: {stat: {dn: -69000, up: 69000}, 'sys,background': {dn: -10, up: 10}, 'sys,detector': {dn: -6600, up: 6600}}, 1: {stat: {dn: -100000, up: 100000}, 'sys,background': {dn: -400, up: 400}, 'sys,detector': {dn: -9000, up: 9000}}, 2: {stat: {dn: -80000, up: 80000}, 'sys,background': {dn: -300, up: 300}, 'sys,detector': {dn: -10000, up: 10000}}, 3: {stat: {dn: -50000, up: 50000}, 'sys,background': {dn: -300, up: 300}, 'sys,detector': {dn: -2000, up: 2000}}}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d05-x01-y01
 Title: Table 5
@@ -83,6 +93,8 @@ Type: Scatter2D
 2.420795e+00	7.207950e-01	7.207950e-01	4.200000e+05	5.004088e+04	5.004088e+04
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d06-x01-y01
+ErrorBreakdown: {0: {stat: {dn: -4400, up: 4400}, 'sys,background': {dn: -1900, up: 1900}, 'sys,detector': {dn: -300, up: 300}}, 1: {stat: {dn: -2630, up: 2630}, 'sys,background': {dn: -280, up: 280}, 'sys,detector': {dn: -230, up: 230}}, 2: {stat: {dn: -1210, up: 1210}, 'sys,background': {dn: -480, up: 480}, 'sys,detector': {dn: -60, up: 60}}}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d06-x01-y01
 Title: Table 8
@@ -94,6 +106,8 @@ Type: Scatter2D
 3.500000e+02	5.000000e+01	5.000000e+01	3.680000e+03	1.303112e+03	1.303112e+03
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d07-x01-y01
+ErrorBreakdown: {}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d07-x01-y01
 Title: Table 9
@@ -114,6 +128,8 @@ Type: Scatter2D
 4.875000e+02	1.250000e+01	1.250000e+01	2.000000e+00	0.000000e+00	0.000000e+00
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d07-x01-y02
+ErrorBreakdown: {0: {error: {dn: -0.0, up: 0.0}}, 1: {error: {dn: -0.51, up: 0.41}}, 2: {error: {dn: -0.26, up: 0.41}}, 3: {error: {dn: -0.19, up: 0.12}}, 4: {error: {dn: -0.15, up: 0.16}}, 5: {error: {dn: -0.16, up: 0.19}}, 6: {error: {dn: -0.55, up: 0.56}}, 7: {error: {dn: -0.15, up: 0.1}}, 8: {error: {dn: -0.1, up: 0.11}}, 9: {error: {dn: -0.08, up: 0.08}}, 10: {error: {dn: -0.33, up: 0.33}}, 11: {error: {dn: -0.14, up: 0.17}}}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d07-x01-y02
 Title: Table 9
@@ -134,6 +150,8 @@ Type: Scatter2D
 4.875000e+02	1.250000e+01	1.250000e+01	1.600000e-01	1.400000e-01	1.700000e-01
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d07-x01-y03
+ErrorBreakdown: {}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d07-x01-y03
 Title: Table 9
@@ -154,6 +172,8 @@ Type: Scatter2D
 4.875000e+02	1.250000e+01	1.250000e+01	9.300000e-01	0.000000e+00	0.000000e+00
 END YODA_SCATTER2D_V2
 BEGIN YODA_SCATTER2D_V2 /REF/RIVET_ANALYSIS_NAME/d07-x01-y04
+ErrorBreakdown: {}
+
 IsRef: 1
 Path: /REF/RIVET_ANALYSIS_NAME/d07-x01-y04
 Title: Table 9

--- a/hepdata_converter/writers/root_writer.py
+++ b/hepdata_converter/writers/root_writer.py
@@ -175,25 +175,8 @@ class THFRootClass(ObjectWrapper):
 
             if not is_number_list[i]: continue # skip non-numeric y values
 
-            # process the labels to ensure uniqueness
-            observed_error_labels = {}
-            for error in value.get('errors', []):
-                label = error.get('label', '')
-
-                if label not in observed_error_labels:
-                    observed_error_labels[label] = 0
-                observed_error_labels[label] += 1
-
-                if observed_error_labels[label] > 1:
-                    error['label'] = label + '_' + str(observed_error_labels[label])
-
-                # append "_1" to first error label that has a duplicate
-                if observed_error_labels[label] == 2:
-                    for error1 in value.get('errors', []):
-                        error1_label = error1.get('label', 'error')
-                        if error1_label == label:
-                            error1['label'] = label + "_1"
-                            break
+            # process the error labels to ensure uniqueness
+            ArrayWriter.process_error_labels(value)
 
             for error in value.get('errors', []):
                 if 'label' not in error:

--- a/hepdata_converter/writers/yoda_writer.py
+++ b/hepdata_converter/writers/yoda_writer.py
@@ -38,15 +38,15 @@ class ScatterYodaClass(ObjectWrapper):
             for dim_i in xrange(self.dim):
                 args.append([self.xerr_minus[dim_i][i], self.xerr_plus[dim_i][i]])
             args.append([self.yerr_minus[i], self.yerr_plus[i]])
-             
+            
             graph.addPoint(self.get_point_cls()(*args))
-        error_breakdown = yaml.dump(self.err_breakdown, default_flow_style=True, default_style='',width=1e6)
-        graph.setAnnotation("ErrorBreakdown",error_breakdown)
+        error_breakdown = yaml.safe_dump(self.err_breakdown, default_flow_style=True, default_style='', width=1e6)
+        graph.setAnnotation("ErrorBreakdown", error_breakdown)
         return graph
+
 
     def create_objects(self):
         self.calculate_total_errors()
-        self.make_error_breakdown()
 
         graph = self._create_scatter()
 

--- a/hepdata_converter/writers/yoda_writer.py
+++ b/hepdata_converter/writers/yoda_writer.py
@@ -1,6 +1,6 @@
 from hepdata_converter.common import Option
 from hepdata_converter.writers.array_writer import ArrayWriter, ObjectWrapper, ObjectFactory
-import yoda
+import yoda, yaml
 
 
 class ScatterYodaClass(ObjectWrapper):
@@ -32,20 +32,21 @@ class ScatterYodaClass(ObjectWrapper):
 
         for i in xrange(len(self.yval)):
             args = []
-
             for dim_i in xrange(self.dim):
                 args.append(self.xval[dim_i][i])
             args.append(self.yval[i])
             for dim_i in xrange(self.dim):
                 args.append([self.xerr_minus[dim_i][i], self.xerr_plus[dim_i][i]])
             args.append([self.yerr_minus[i], self.yerr_plus[i]])
-
+             
             graph.addPoint(self.get_point_cls()(*args))
-
+        error_breakdown = yaml.dump(self.err_breakdown, default_flow_style=True, default_style='',width=1e6)
+        graph.setAnnotation("Error_Breakdown",error_breakdown)
         return graph
 
     def create_objects(self):
         self.calculate_total_errors()
+        self.make_error_breakdown()
 
         graph = self._create_scatter()
 

--- a/hepdata_converter/writers/yoda_writer.py
+++ b/hepdata_converter/writers/yoda_writer.py
@@ -41,7 +41,7 @@ class ScatterYodaClass(ObjectWrapper):
              
             graph.addPoint(self.get_point_cls()(*args))
         error_breakdown = yaml.dump(self.err_breakdown, default_flow_style=True, default_style='',width=1e6)
-        graph.setAnnotation("Error_Breakdown",error_breakdown)
+        graph.setAnnotation("ErrorBreakdown",error_breakdown)
         return graph
 
     def create_objects(self):


### PR DESCRIPTION
Hi Graeme/HEPData team,

As discussed at a previous LHC EW WG meeting, it would be nice to be able to include an annotation with the error breakdown in the header when converting HEPData records to YODA format. This PR does exactly that.

This PR will not pass the unit tests because it changes the YODA output by adding an extra line per analysis object. Let me know if you'd like me to make any additional changes (eg to the test yoda files) to remedy that. Or indeed if you have any other suggestions or requests.

Many thanks,

Louie
