### PR TITLE
Feature/root yoda updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - '3.7'
+  - '3.8'
 
 cache:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 script:
   - export CURRENT_PATH=`pwd`
   - docker run -v $CURRENT_PATH:$CURRENT_PATH $DOCKER_IMAGE /bin/bash -c "cd $CURRENT_PATH && coverage run -m unittest discover hepdata_converter/testsuite 'test_*'"
-  - docker run -v $CURRENT_PATH:$CURRENT_PATH $DOCKER_IMAGE /bin/bash -c "cd $CURRENT_PATH && python setup.py install && hepdata-converter -v"
+  - docker run -v $CURRENT_PATH:$CURRENT_PATH $DOCKER_IMAGE /bin/bash -c "cd $CURRENT_PATH && python3 setup.py install && hepdata-converter -v"
 
 after_success:
   - coveralls

--- a/hepdata_converter/parsers/yaml_parser.py
+++ b/hepdata_converter/parsers/yaml_parser.py
@@ -9,7 +9,6 @@ from hepdata_validator import LATEST_SCHEMA_VERSION
 from hepdata_validator.submission_file_validator import SubmissionFileValidator
 from hepdata_validator.data_file_validator import DataFileValidator
 from hepdata_converter.parsers import Parser, ParsedData, Table
-from multiprocessing import Pool
 import os, re
 
 # Allow for a bug in PyYAML where numbers like 1e+04 are parsed as strings not as floats.
@@ -30,8 +29,6 @@ class YAML(Parser):
     help = 'Parses New HEPData YAML format. Input parameter should be path to ' \
            'the directory where submission.yaml file ' \
            'is present (or direct filepath to the submission.yaml file)'
-
-    pool = Pool()
 
     def __init__(self, *args, **kwargs):
         super(YAML, self).__init__(*args, **kwargs)

--- a/hepdata_converter/writers/root_writer.py
+++ b/hepdata_converter/writers/root_writer.py
@@ -5,6 +5,7 @@ import ROOT as ROOTModule
 import array
 import tempfile
 import os
+from ctypes import c_char_p
 from hepdata_converter.writers.utils import error_value_processor
 
 __author__ = 'Michał Szostak'
@@ -452,8 +453,9 @@ class ROOT(ArrayWriter):
             output.Flush()
             output.ReOpen('read')
             file_size = output.GetSize()
-            buff = bytearray(file_size)
-            output.ReadBuffer(buff, file_size)
+            buff = bytes(file_size)
+            c_buff = c_char_p(buff)
+            output.ReadBuffer(c_buff, file_size)
             data_out.write(buff)
 
         if self.file_emulation:


### PR DESCRIPTION
Updates to work with [latest version of hepdata-converter-docker](https://github.com/HEPData/hepdata-converter-docker/pull/8)

 * pyROOT is now based on cppyy so fixed an issue with type handling
 * python3.8 caused an issue with pools which were created but not used, so they were removed

Tested using the [root-yoda-updates](https://github.com/HEPData/hepdata-converter-docker/tree/root-yoda-updates) branch of hepdata-converter-docker:

```bash
cd hepdata-converter-docker
docker build . -t hepdata-converter
cd ../hepdata-converter
export DOCKER_IMAGE=hepdata-converter
./run-tests.sh
```

Fixes #7 