### PR TITLE
YODA writer: Skip ill-defined error components

### DIFF
--- a/hepdata_converter/writers/yoda_writer.py
+++ b/hepdata_converter/writers/yoda_writer.py
@@ -42,13 +42,14 @@ class EstimateYodaClass(ObjectWrapper):
             return
         errs = self.err_breakdown[idx]
         nSources = len(errs.keys())
-        for source in errs:
+        for source, vals in errs.items():
+            if not vals:  continue
             label = source
             if label.upper() == "TOTAL" or \
                 (nSources == 1 and source == 'error'):
                 label = '' # total uncertainty
-            errUp = errs[source]['up']
-            errDn = errs[source]['dn']
+            errUp = vals['up']
+            errDn = vals['dn']
             estimate.setErr([errDn, errUp], label)
 
     def _create_estimate(self):


### PR DESCRIPTION
Hi,

the last column in Table 13 of [this entry](https://www.hepdata.net/record/ins1253360) has a `+/- none` error component in each cell. This seems to be related to a `TypeError` coming from the array writer:

```
ERROR:hepdata_converter.writers.array_writer:TypeError encountered when parsing none
ERROR:hepdata_converter.writers.array_writer:TypeError encountered when parsing none
ERROR:hepdata_converter.writers.array_writer:TypeError encountered when parsing none
```

... and is currently causing the YODA2 writer to crash for this entry. This change set skips such components in order to work around the issue, but we also might want to add a check for this sort of thing as part of the upload procedure (unless we're doing that already and this is just an artefact of the old-to-new HepData migration? 🤷 ).

Cheers,
Chris