### PR TITLE
Replace `find_module` and `load_module` for Python 3.12 compatibilty

### DIFF
--- a/hepdata_converter/parsers/__init__.py
+++ b/hepdata_converter/parsers/__init__.py
@@ -7,6 +7,7 @@ __all__ = []
 
 import pkgutil
 import inspect
+from importlib.util import module_from_spec
 
 
 class BadFormat(Exception):
@@ -175,7 +176,9 @@ class Parser(GetConcreteSubclassMixin, OptionInitMixin, metaclass=abc.ABCMeta):
 
 # import all packages in the parsers package, so that Parser.get_specific_parser will recognise them
 for loader, name, is_pkg in pkgutil.walk_packages(__path__):
-    module = loader.find_module(name).load_module(name)
+    spec = loader.find_spec(name)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
 
     for name, value in inspect.getmembers(module):
         if name.startswith('__'):

--- a/hepdata_converter/writers/__init__.py
+++ b/hepdata_converter/writers/__init__.py
@@ -6,6 +6,7 @@ from hepdata_converter.common import GetConcreteSubclassMixin, OptionInitMixin
 __all__ = []
 
 import abc
+from importlib.util import module_from_spec
 
 
 class Writer(GetConcreteSubclassMixin, OptionInitMixin, metaclass=abc.ABCMeta):
@@ -36,7 +37,9 @@ class Writer(GetConcreteSubclassMixin, OptionInitMixin, metaclass=abc.ABCMeta):
 
 # import all packages in the parsers package, so that Writer.get_specific_writer will recognise them
 for loader, name, is_pkg in pkgutil.walk_packages(__path__):
-    module = loader.find_module(name).load_module(name)
+    spec = loader.find_spec(name)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
 
     for name, value in inspect.getmembers(module):
         if name.startswith('__'):


### PR DESCRIPTION
* `find_module` deprecated since Python 3.10 and removed in Python 3.12.
* `load_module` deprecated since Python 3.4.
* Closes #57.