### PR TITLE
Avoid 'new line' symbols in string edges (YODA writer)

### DIFF
--- a/hepdata_converter/writers/yoda_writer.py
+++ b/hepdata_converter/writers/yoda_writer.py
@@ -103,7 +103,7 @@ class EstimateYodaClass(ObjectWrapper):
                     v = self.xval[dim_i][i]
                     m = self.xerr_minus[dim_i][i]
                     p = self.xerr_plus[dim_i][i]
-                    edge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v)
+                    edge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v.replace('\n', ' '))
                     if edge not in thisaxis:
                         thisaxis.append(edge)
             edges.append(sorted(thisaxis) if isCAxis[-1] else thisaxis)
@@ -145,7 +145,7 @@ class EstimateYodaClass(ObjectWrapper):
                 elif isIntAxis[dim_i]:
                     edges.append(int(v))
                 else:
-                    newedge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v)
+                    newedge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v.replace('\n', ' '))
                     edges.append(newedge)
             # calculate global index
             idx = rtn.indexAt(*edges)

--- a/hepdata_converter/writers/yoda_writer.py
+++ b/hepdata_converter/writers/yoda_writer.py
@@ -103,7 +103,7 @@ class EstimateYodaClass(ObjectWrapper):
                     v = self.xval[dim_i][i]
                     m = self.xerr_minus[dim_i][i]
                     p = self.xerr_plus[dim_i][i]
-                    edge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v.replace('\n', ' '))
+                    edge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v).replace('\n', ' ')
                     if edge not in thisaxis:
                         thisaxis.append(edge)
             edges.append(sorted(thisaxis) if isCAxis[-1] else thisaxis)
@@ -145,7 +145,7 @@ class EstimateYodaClass(ObjectWrapper):
                 elif isIntAxis[dim_i]:
                     edges.append(int(v))
                 else:
-                    newedge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v.replace('\n', ' '))
+                    newedge = '{0} - {1}'.format(v-m, v+p) if m and p else str(v).replace('\n', ' ')
                     edges.append(newedge)
             # calculate global index
             idx = rtn.indexAt(*edges)


### PR DESCRIPTION
Hi,

I came across a recent [submission from CMS](https://www.hepdata.net/record/ins2709669) that encodes the string edges for the independent axis in [Table 2](https://www.hepdata.net/record/ins2709669?version=2&table=Table%202) like so:

```
  - value: |-
      $c\overline{c}>H\gamma>e
      u_e\mu
      u_\mu\gamma$
```

which is an edge that involves two new line characters. These are not preserved by the browser-based view of the associated entry: it prints the edge in one line, which was presumably the intention anyway, but that is not necessarily the case for all output formats. I noticed them being propagated through by the YODA writer, which later on causes the reader to crash (which is a separate issue that I will deal with on the YODA side).

For the sake of this entry (and possibly others), I would propose to remove new-line characters entirely from string-based bin edges when assembling the YODA objects, as done in this change set.