### PR TITLE
Add support for underflow/overflow bins in ROOT export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.12
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     - name: Install pip dependencies

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ This Python 3 library provides support for converting:
 * Old HepData input format (`sample <https://github.com/HEPData/hepdata-submission/blob/main/examples/oldhepdata/sample.oldhepdata>`_) to `YAML <https://github.com/HEPData/hepdata-submission>`_
 * `YAML <https://github.com/HEPData/hepdata-submission>`_ to:
 
-  * `ROOT <https://root.cern.ch>`_ (tested with v6.32/04)
+  * `ROOT <https://root.cern.ch>`_ (tested with v6.32.04)
   * `YODA <https://yoda.hepforge.org>`_ (tested with v2.1.0)
   * `CSV <https://en.wikipedia.org/wiki/Comma-separated_values>`_
 

--- a/hepdata_converter/testsuite/test_rootwriter.py
+++ b/hepdata_converter/testsuite/test_rootwriter.py
@@ -78,8 +78,7 @@ class ROOTWriterTestSuite(WriterTestSuite):
         f_orig.Close()
 
     @insert_path('yaml_full')
-    @insert_path('root/full.root')
-    def test_th1_parse(self, yaml_full_path, full_root_path):
+    def test_th1_parse(self, yaml_full_path):
         output_file_path = os.path.join(self.current_tmp, 'datafile.root')
         hepdata_converter.convert(yaml_full_path, output_file_path,
                                   options={'output_format': 'root',
@@ -97,3 +96,10 @@ class ROOTWriterTestSuite(WriterTestSuite):
                                                'hepdata_doi': '10.17182/hepdata.12345.v1'})
 
             self.assertNotEqual(os.stat(output_file_path).st_size, 0, 'output root file is empty')
+
+    @insert_path('yaml_inf')
+    def test_parse_with_overflows(self, yaml_inf_path):
+        output_file_path = os.path.join(self.current_tmp, 'data-inf.root')
+        hepdata_converter.convert(yaml_inf_path, output_file_path,
+                                  options={'output_format': 'root'})
+        pass

--- a/hepdata_converter/version.py
+++ b/hepdata_converter/version.py
@@ -1,3 +1,3 @@
 # this file ideally should only contain __version__ declaration, as anything else
 # may break setup.py and PyPI uploads
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/hepdata_converter/writers/root_writer.py
+++ b/hepdata_converter/writers/root_writer.py
@@ -5,6 +5,7 @@ import ROOT as ROOTModule
 import array
 import tempfile
 import os
+import math
 from ctypes import c_char_p
 from hepdata_converter.writers.utils import error_value_processor
 
@@ -55,31 +56,36 @@ class THFRootClass(ObjectWrapper, metaclass=abc.ABCMeta):
 
         name = "Hist%sD_y%s_e%s" % (self.dim, self.dependent_variable_index + 1, index)
 
-        # order bin values of independent variables
+        # order bin values of independent variables and check if underflow/overflow bins present
         xval_ordered = []
+        underflow = []
+        overflow = []
         for i in range(self.dim):
             xval_ordered.append([])
             xval_ordered[i] = sorted(xval[i])
+            nbinsi = len(xval_ordered[i]) - 1
+            underflow.append(1 if not math.isfinite(xval_ordered[i][0]) else 0)
+            overflow.append(1 if not math.isfinite(xval_ordered[i][nbinsi]) else 0)
 
         if 1 == self.dim:
-            nbinsx = len(xval_ordered[0]) - 1
-            binsx = array.array('d', xval_ordered[0])
+            nbinsx = len(xval_ordered[0]) - 1 - underflow[0] - overflow[0]
+            binsx = array.array('d', xval_ordered[0][underflow[0]:nbinsx+2])
             hist = self.get_hist_classes()[self.dim - 1](self.sanitize_name(name), '', nbinsx, binsx)
 
         if 2 == self.dim:
-            nbinsx = len(xval_ordered[0]) - 1
-            binsx = array.array('d', xval_ordered[0])
-            nbinsy = len(xval_ordered[1]) - 1
-            binsy = array.array('d', xval_ordered[1])
+            nbinsx = len(xval_ordered[0]) - 1 - underflow[0] - overflow[0]
+            binsx = array.array('d', xval_ordered[0][underflow[0]:nbinsx+2])
+            nbinsy = len(xval_ordered[1]) - 1 - underflow[1] - overflow[1]
+            binsy = array.array('d', xval_ordered[1][underflow[1]:nbinsy+2])
             hist = self.get_hist_classes()[self.dim - 1](self.sanitize_name(name), '', nbinsx, binsx, nbinsy, binsy)
 
         if 3 == self.dim:
-            nbinsx = len(xval_ordered[0]) - 1
-            binsx = array.array('d', xval_ordered[0])
-            nbinsy = len(xval_ordered[1]) - 1
-            binsy = array.array('d', xval_ordered[1])
-            nbinsz = len(xval_ordered[2]) - 1
-            binsz = array.array('d', xval_ordered[2])
+            nbinsx = len(xval_ordered[0]) - 1 - underflow[0] - overflow[0]
+            binsx = array.array('d', xval_ordered[0][underflow[0]:nbinsx+2])
+            nbinsy = len(xval_ordered[1]) - 1 - underflow[1] - overflow[1]
+            binsy = array.array('d', xval_ordered[1][underflow[1]:nbinsy+2])
+            nbinsz = len(xval_ordered[2]) - 1 - underflow[2] - overflow[2]
+            binsz = array.array('d', xval_ordered[2][underflow[2]:nbinsz+2])
             hist = self.get_hist_classes()[self.dim - 1](self.sanitize_name(name), '', nbinsx, binsx, nbinsy, binsy, nbinsz, binsz)
 
         for i in range(self.dim):
@@ -105,31 +111,36 @@ class THFRootClass(ObjectWrapper, metaclass=abc.ABCMeta):
         name = "Hist%sD_y%s" % (self.dim, self.dependent_variable_index + 1)
         args = []
 
-        # order bin values of independent variables
+        # order bin values of independent variables and check if underflow/overflow bins present
         xval_ordered = []
+        underflow = []
+        overflow = []
         for i in range(self.dim):
             xval_ordered.append([])
             xval_ordered[i] = sorted(xval[i])
+            nbinsi = len(xval_ordered[i]) - 1
+            underflow.append(1 if not math.isfinite(xval_ordered[i][0]) else 0)
+            overflow.append(1 if not math.isfinite(xval_ordered[i][nbinsi]) else 0)
 
         if 1 == self.dim:
-            nbinsx = len(xval_ordered[0]) - 1
-            binsx = array.array('d', xval_ordered[0])
+            nbinsx = len(xval_ordered[0]) - 1 - underflow[0] - overflow[0]
+            binsx = array.array('d', xval_ordered[0][underflow[0]:nbinsx+2])
             hist = self.get_hist_classes()[self.dim - 1](self.sanitize_name(name), '', nbinsx, binsx)
 
         if 2 == self.dim:
-            nbinsx = len(xval_ordered[0]) - 1
-            binsx = array.array('d', xval_ordered[0])
-            nbinsy = len(xval_ordered[1]) - 1
-            binsy = array.array('d', xval_ordered[1])
+            nbinsx = len(xval_ordered[0]) - 1 - underflow[0] - overflow[0]
+            binsx = array.array('d', xval_ordered[0][underflow[0]:nbinsx+2])
+            nbinsy = len(xval_ordered[1]) - 1 - underflow[1] - overflow[1]
+            binsy = array.array('d', xval_ordered[1][underflow[1]:nbinsy+2])
             hist = self.get_hist_classes()[self.dim - 1](self.sanitize_name(name), '', nbinsx, binsx, nbinsy, binsy)
 
         if 3 == self.dim:
-            nbinsx = len(xval_ordered[0]) - 1
-            binsx = array.array('d', xval_ordered[0])
-            nbinsy = len(xval_ordered[1]) - 1
-            binsy = array.array('d', xval_ordered[1])
-            nbinsz = len(xval_ordered[2]) - 1
-            binsz = array.array('d', xval_ordered[2])
+            nbinsx = len(xval_ordered[0]) - 1 - underflow[0] - overflow[0]
+            binsx = array.array('d', xval_ordered[0][underflow[0]:nbinsx+2])
+            nbinsy = len(xval_ordered[1]) - 1 - underflow[1] - overflow[1]
+            binsy = array.array('d', xval_ordered[1][underflow[1]:nbinsy+2])
+            nbinsz = len(xval_ordered[2]) - 1 - underflow[2] - overflow[2]
+            binsz = array.array('d', xval_ordered[2][underflow[2]:nbinsz+2])
             hist = self.get_hist_classes()[self.dim - 1](self.sanitize_name(name), '', nbinsx, binsx, nbinsy, binsy, nbinsz, binsz)
 
         for i in range(self.dim):
@@ -246,6 +257,9 @@ class THFRootClass(ObjectWrapper, metaclass=abc.ABCMeta):
                 if x['high'] not in xval[i]:
                     xval[i].append(x['high'])
 
+        if not any(xval):
+            return []
+
         try:
             hist = self._create_hist(xval)
         except:
@@ -280,7 +294,7 @@ class TGraph2DErrorsClass(ObjectWrapper):
         return False
 
     def create_objects(self):
-        self.calculate_total_errors()
+        self.calculate_total_errors(for_tgraph=True)
 
         # check that errors are symmetric (within a tolerance to allow for numerical rounding)
         tol = 1e-15
@@ -335,7 +349,7 @@ class TGraphAsymmErrorsRootClass(ObjectWrapper):
         return False
 
     def create_objects(self):
-        self.calculate_total_errors()
+        self.calculate_total_errors(for_tgraph=True)
 
         if len(self.xval[0]):
             graph = ROOTModule.TGraphAsymmErrors(len(self.xval[0]),

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open('README.rst', 'rt') as fp:
 setup(
     name='hepdata-converter',
     version=get_version(),
-    install_requires=['hepdata-validator>=0.3.5'],
+    install_requires=['hepdata-validator>=0.3.6'],
     entry_points={
         'console_scripts': [
             'hepdata-converter = hepdata_converter:main',


### PR DESCRIPTION
Together with #56 (already merged), this PR closes #55.  The first bin (with index 0) of a ROOT histogram will contain the underflow, while the last bin will contain the overflow.  For objects like ROOT `TGraphAsymmErrors` that do not support underflow/overflow bins, the workaround implemented is to set the low/centre/high bin values all to the finite bin limit as in the HEPData visualisation code (see [commit](https://github.com/HEPData/hepdata/commit/5a372ec4ce2e5afe56dd633fad1277c7b09c8c89)).